### PR TITLE
Update many links from NCTU to NYCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@
 	- [資訊工程學系](#資訊工程學系)
 
 ## 入口相關
-- [單一入口](https://portal.nctu.edu.tw/portal/login.php)
-- [社團入口](https://clubportal.nctu.edu.tw/bulletins)
-- [交大網站導覽](https://www.nctu.edu.tw/sitemap)
+- [單一入口](https://portal.nycu.edu.tw/portal/login.php)
+- [社團入口](https://clubportal.nycu.edu.tw/bulletins)
+- [交大網站導覽](https://www.nycu.edu.tw/nycu/ch/sitemap)
 
 ## 課程相關
 
-- [數位教學平臺E3](https://e3new.nctu.edu.tw/my/)
-- [學生請假系統](https://stuoffcourse.nctu.edu.tw/)
-- [課程時間表](https://timetable.nctu.edu.tw/)
-- [科系必修科目表](https://academic.nctu.edu.tw/chcourse/class03.aspx?ftype=3)
-- [交大 OCW](https://ocw.nctu.edu.tw)
+- [數位教學平臺E3](https://e3p.nycu.edu.tw/)
+- [學生請假系統](https://portal.nycu.edu.tw/#/redirect/stuoffcourse)
+- [課程時間表](https://timetable.nycu.edu.tw/)
+- [科系必修科目表](https://aa.nycu.edu.tw/aa/ch/app/data/list?module=nycu0069&id=2511)
+- [交大 OCW](https://ocw.nycu.edu.tw)
 - [交大線上學習系統](https://dcpc.nctu.edu.tw/nctu_online/)
 - [Easy Test (全民英檢模擬測驗)](http://140.113.9.17/)
 
@@ -40,19 +40,19 @@
 - [NCTU Timetable+](https://timetable.csy54.tw/)
 - [交大個人助理](https://course.nctu.xyz/)
 - [交大預排課表小工具](https://lys0829.github.io/NCTUPreTimetable/)
-- [網路選課系統](https://course.nctu.edu.tw/)
-- [暑修選課系統](https://summercourse.nctu.edu.tw/)
+- [網路選課系統](https://course.nycu.edu.tw/)
+- [暑修選課系統](https://summercourse.nycu.edu.tw/)
 
 ## 學籍成績相關
 
-- [學籍成績系統](https://regist.nctu.edu.tw/)
-- [學籍成績文件申請系統](https://regapp.nctu.edu.tw/Views/User/UserLogin)
-- [學雜費管理系統](https://tuition.nctu.edu.tw/cashier/Main.asp)
+- [學籍成績系統](https://portal.nycu.edu.tw/#/redirect/regist)
+- [學籍成績文件申請系統](https://regapp.nycu.edu.tw/Views/User/UserLogin)
+- [學雜費管理系統](https://portal.nycu.edu.tw/#/redirect/Tuition)
 
 ## 校園服務相關
 
-- [宿舍服務](http://housing.sa.nctu.edu.tw)
-- [汽機車申請](https://www.ga.nctu.edu.tw/security-division/parking)
+- [宿舍服務](https://osa.nycu.edu.tw/osa/ch/app/folder/3464)
+- [汽機車申請](https://ga.nycu.edu.tw/ga/ch/app/data/list?module=nycu0038&id=5219)
 - [教室借用系統](https://course.nctu.edu.tw/CRManage/usr_Default.aspx)
 - [離校系統](https://reg-grad.nctu.edu.tw/)
 - [校內工讀系統](https://parttime.nctu.edu.tw/)


### PR DESCRIPTION
Not done updating every link yet, but tried to update some.

These systems seem to be deprecated, are they?
- 交大線上學習系統
- Easy Test (全民英檢模擬測驗)
- NCTU+
- NCTUwU 交大選課模擬器
- Nice Course To U
- NCTU Timetable+
- 交大個人助理